### PR TITLE
fix: use grub as bootloader for SBCs

### DIFF
--- a/profiles/jetson_nano/jetson_nano.yaml
+++ b/profiles/jetson_nano/jetson_nano.yaml
@@ -7,3 +7,4 @@ output:
   imageOptions:
     diskSize: 1306525696
     diskFormat: raw
+    bootloader: grub


### PR DESCRIPTION
Part of: https://github.com/siderolabs/talos/issues/10859