### PR TITLE
fix: directory creation permissions

### DIFF
--- a/installers/jetson_nano/src/main.go
+++ b/installers/jetson_nano/src/main.go
@@ -64,7 +64,7 @@ func (i *JetsonNanoInstaller) Install(options overlay.InstallOptions[jetsonNanoE
 	src := filepath.Join(options.ArtifactsPath, "arm64/dtb", dtb)
 	dst := filepath.Join(options.MountPrefix, "/boot/EFI/dtb", dtb)
 
-	err = os.MkdirAll(filepath.Dir(dst), 0o600)
+	err = os.MkdirAll(filepath.Dir(dst), 0o700)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
If `0o700` is not set `os.MkdirAll` fails to run as non-root since execute bit is not set.

Part of: https://github.com/siderolabs/overlays/issues/194